### PR TITLE
cicd: Use cargo-cache 0.6.2 to avoid 2021 edition requirement

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -64,5 +64,5 @@ jobs:
 
       - name: Clear the cargo caches
         run: |
-          cargo install cargo-cache --no-default-features --features ci-autoclean
+          cargo install cargo-cache --version 0.6.2 --no-default-features --features ci-autoclean
           cargo-cache


### PR DESCRIPTION
Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>
